### PR TITLE
add support for green-button merges

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Commit object properties:
   - `files`: the number of files changed
   - `insertions`: the number of new lines inserted
   - `deletions`: the number of old lines removed
-* `prUrl`: a URL pointing to a pull-request where this change was made if the commit metadata contains a `PR-URL: https://github.com/user/project/pull/XX` line. Note that whatever proceeds the `PR-URL: ` string will be collected in this property; one exception being that if a shortened `#XX` version is found and you have supplied `defaultGitHubUser` and `defaultGitHubProject` arguments to the constructor then a full GitHub pull-request will be reconstituted in its place.
+* `prUrl`: a URL pointing to a pull-request where this change was made if the commit metadata contains a `PR-URL: https://github.com/user/project/pull/XX` line. Note that whatever proceeds the `PR-URL: ` string will be collected in this property; one exception being that if a shortened `#XX` version is found and you have supplied `defaultGitHubUser` and `defaultGitHubProject` arguments to the constructor then a full GitHub pull-request will be reconstituted in its place. Also, if a commit message line ends with ` (#XX)` as is done with green-button merges, this will be used.
 * `ghUser`, `ghProject, `ghIssue`: if a proper GitHub pull request is found for the `prUrl` property (including shortened `#XX` ones), these properties will be added to point to the original user, project and issue (pull-request) for this change, as extracted from the URL.
 
 ## License

--- a/commit-stream.js
+++ b/commit-stream.js
@@ -45,7 +45,7 @@ function commitStream (ghUser, ghProject) {
       if (!commit.reviewers)
         commit.reviewers = []
       commit.reviewers.push({ name: m[1], email: m[2] })
-    } else if (m = line.match(/^\s+PR(?:[- ]?URL)?:?\s*(.+)\s*$/)) {
+    } else if (m = line.match(/^\s+PR(?:[- ]?URL)?:?\s*(.+)\s*$/) || line.match(/\(#(\d+)\)$/)) {
       commit.prUrl = m[1]
       if (ghUser && ghProject && (m = commit.prUrl.match(/^\s*#?(\d+)\s*$/))) {
         commit.prUrl = 'https://github.com/' + ghUser + '/' + ghProject + '/pull/' + m[1]
@@ -54,6 +54,9 @@ function commitStream (ghUser, ghProject) {
         commit.ghIssue   = +m[4]
         commit.ghUser    = m[2]
         commit.ghProject = m[3]
+      }
+      if ((m = line.match(/^    (.*)\s\(#\d+\)$/)) && !commit.summary) {
+        commit.summary = m[1]
       }
     } else if (/^    /.test(line) && (line = line.trim()).length) {
       if (!commit.summary) {


### PR DESCRIPTION
This allows this package (and dependent packages) to be used with many repositories that are not `nodejs/node`.