### PR TITLE
feat: add support for green-button merges

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Commit object properties:
   - `insertions`: the number of new lines inserted
   - `deletions`: the number of old lines removed
 - `prUrl`: a URL pointing to a pull-request where this change was made if the commit metadata contains a `PR-URL: https://github.com/user/project/pull/XX` line. Note that whatever proceeds the `PR-URL: ` string will be collected in this property; one exception being that if a shortened `#XX` version is found and you have supplied `defaultGitHubUser` and `defaultGitHubProject` arguments to the constructor then a full GitHub pull-request will be reconstituted in its place.
-- `ghUser`, `ghProject`, `ghIssue`: if a proper GitHub pull request is found for the `prUrl` property (including shortened `#XX` ones), these properties will be added to point to the original user, project and issue (pull-request) for this change, as extracted from the URL.
+- `ghUser`, `ghProject`, `ghIssue`: if a proper GitHub pull request is found for the `prUrl` property (including shortened `#XX` ones), these properties will be added to point to the original user, project and issue (pull-request) for this change, as extracted from the URL. Also, if a commit message line ends with ` (#XX)` as is done with green-button merges, this will be used.
 
 ## License
 

--- a/commit-stream.js
+++ b/commit-stream.js
@@ -46,7 +46,7 @@ export default function commitStream (ghUser, ghProject) {
         commit.reviewers = []
       }
       commit.reviewers.push({ name: m[1], email: m[2] })
-    } else if ((m = line.match(/^\s+PR(?:[- ]?URL)?:?\s*(.+)\s*$/)) !== null) {
+    } else if ((m = line.match(/^\s+PR(?:[- ]?URL)?:?\s*(.+)\s*$/) || line.match(/\(#(\d+)\)$/)) !== null) {
       commit.prUrl = m[1]
       if (
         typeof ghUser === 'string' &&
@@ -65,6 +65,9 @@ export default function commitStream (ghUser, ghProject) {
         commit.ghIssue = parseInt(m[4])
         commit.ghUser = m[2]
         commit.ghProject = m[3]
+      }
+      if ((m = line.match(/^ {4}(.*)\s\(#\d+\)$/)) && !commit.summary) {
+        commit.summary = m[1]
       }
     } else if (/^ {4}/.test(line) && (line = line.trim()).length !== 0) {
       if (commit.summary === undefined || commit.summary === null) {

--- a/test.js
+++ b/test.js
@@ -6,7 +6,12 @@ import listStream from 'list-stream'
 import { pipeline } from 'readable-stream'
 import bl from 'bl'
 
-function gitToList (t, gitCmd, callback) {
+function gitToList (t, gitCmd, user, repo, callback) {
+  if (typeof user === 'function') {
+    callback = user
+    user = undefined
+    repo = undefined
+  }
   const child = spawn('bash', ['-c', gitCmd])
   child.stderr.pipe(bl((_, out) => {
     t.strictEqual(out.toString(), '')
@@ -21,7 +26,7 @@ function gitToList (t, gitCmd, callback) {
   pipeline(
     child.stdout,
     split2(),
-    commitStream(),
+    commitStream(user, repo),
     listStream.obj(callback),
     () => {}
   )
@@ -195,5 +200,27 @@ test('current commit log with changes', (t) => {
       },
       'got correct first commit changes'
     )
+  })
+})
+
+test('current commit log with ghUser and ghRepo passed', function (t) {
+  gitToList(t, 'git log', 'rvagg', 'commit-stream', function (err, list) {
+    t.error(err, 'no error')
+
+    t.ok(list && list.length > 1, 'got a list')
+
+    t.deepEqual(list[list.length - 18], {
+      sha: 'b23208796d7e3fd08b36f6106aa7f027aa827137',
+      authors: [
+        { name: 'Rich Trott', email: 'rtrott@gmail.com' }
+      ],
+      authorDate: 'Mon Oct 11 19:29:18 2021 -0700',
+      prUrl: 'https://github.com/rvagg/commit-stream/pull/5',
+      ghIssue: 5,
+      ghUser: 'rvagg',
+      ghProject: 'commit-stream',
+      author: { name: 'Rich Trott', email: 'rtrott@gmail.com' },
+      summary: 'chore: update strip-ansi to 6.x'
+    }, 'got correct pr url for green-button merge')
   })
 })


### PR DESCRIPTION
I had to reimplement #6 because the changeset was so large, but I managed to do it in a way that preserves commit author.